### PR TITLE
Separation of email notification configuration

### DIFF
--- a/corporate_services/api/timesheet/before_workflow_action.py
+++ b/corporate_services/api/timesheet/before_workflow_action.py
@@ -2,7 +2,6 @@ import frappe
 from frappe import _
 
 def before_workflow_action_timesheet_submission(doc, method):
+    if doc.workflow_state == "Submitted to Supervisor":
+        frappe.throw(_("You must upload a timesheet before submitting to the supervisor for {0}.").format(doc.name))
 
-    if doc.docstatus == 0 and doc.workflow_state == "Submitted to Supervisor" and not doc.timesheet:
-        frappe.throw(_("You must upload a timesheet before submitting to the supervisor."))
-        frappe.msgprint(_("You must upload a timesheet before submitting to the supervisor"))

--- a/corporate_services/hooks.py
+++ b/corporate_services/hooks.py
@@ -138,6 +138,10 @@ def generate_doc_events(event_maps):
             doc_events[doctype][event_type] = method
     return doc_events
 
+before_workflow_action_map = {
+    "Timesheet Submission":"corporate_services.api.timesheet.before_workflow_action.before_workflow_action_timesheet_submission",
+}
+
 on_update_map = {
     "Employee Grievance": "corporate_services.api.notification.notifications.employee_grievance",
     "Travel Request": "corporate_services.api.notification.travel_request.alert",
@@ -145,19 +149,17 @@ on_update_map = {
     "Work Continuity Plan": "corporate_services.api.notification.work_continuity_plan.alert",
     "Asset Custodianship Requisition": "corporate_services.api.notification.asset_custotianship_requisition.alert",
     "Asset Requisition": "corporate_services.api.notification.asset_requisition.alert",
-    "Timesheet Submission":"corporate_services.api.notification.timesheet.alert",
     "Timesheet Submission":"corporate_services.api.timesheet.finance_timesheet_submission.finance_timesheet_submission",
-    
     "Project":"corporate_services.api.notification.project.project_manager.alert"
 }
-before_workflow_action_map = {
-    "Timesheet Submission":"corporate_services.api.timesheet.before_workflow_action.before_workflow_action_timesheet_submission",
+timesheet_notifications ={
+    "Timesheet Submission":"corporate_services.api.notification.timesheet.alert",
 }
-  
   
 event_maps = {
     "on_update": on_update_map,
-    "before_workflow_action" : before_workflow_action_map
+    "on_update" : before_workflow_action_map,
+    "on_update" : timesheet_notifications,
 }
 
 doc_events = generate_doc_events(event_maps)


### PR DESCRIPTION
@brianraila 
- The email notifications for the email were not working
- Restrict one from sending the timesheet to the supervisor while its empty